### PR TITLE
Multi Section TVC wasn't sending notification to cells. Bug #3498

### DIFF
--- a/NCSNavField/MultiSurveyTVC.m
+++ b/NCSNavField/MultiSurveyTVC.m
@@ -115,6 +115,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    [[NSNotificationCenter defaultCenter] postNotificationName:MASTER_VC_DID_SELECT_ROW object:nil];
     [self setActiveSurveyWithSurveyIndex:indexPath.section activeSectionWithSectionIndex:indexPath.row];
 }
 


### PR DESCRIPTION
Similar to Bug #3283, the Multi-Section TVC wasn't notifying the cells to send the resign first responder message to their text fields. I allowed Multi-Section TVC to post the notification enabling it.
