### PR TITLE
Correctly delete a new participant Bug #3640

### DIFF
--- a/NCSFieldConstants.h
+++ b/NCSFieldConstants.h
@@ -1,0 +1,21 @@
+//
+//  NCSFieldConstants.h
+//  NCSNavField
+//
+//  Created by Jacob Van Order on 2/20/13.
+//  Copyright (c) 2013 Northwestern University. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT NSString * ENDPOINT_IMAGE_DOWNLOADED;
+
+FOUNDATION_EXPORT NSString * SettingsDidChangeNotification;
+FOUNDATION_EXPORT NSString * CLIENT_ID;
+FOUNDATION_EXPORT NSString * CORE_URL;
+FOUNDATION_EXPORT NSString * CAS_SERVER_URL;
+FOUNDATION_EXPORT NSString * PGT_RECEIVE_URL;
+FOUNDATION_EXPORT NSString * PGT_RETRIEVE_URL;
+FOUNDATION_EXPORT NSString * PURGE_FIELDWORK_BUTTON;
+FOUNDATION_EXPORT NSString * UPCOMING_DAYS_TO_SYNC;
+FOUNDATION_EXPORT NSString * MANUAL_MODE;

--- a/NCSFieldConstants.m
+++ b/NCSFieldConstants.m
@@ -1,0 +1,21 @@
+//
+//  NCSFieldConstants.m
+//  NCSNavField
+//
+//  Created by Jacob Van Order on 2/20/13.
+//  Copyright (c) 2013 Northwestern University. All rights reserved.
+//
+
+#import "NCSFieldConstants.h"
+
+NSString * ENDPOINT_IMAGE_DOWNLOADED = @"ENDPOINT_IMAGE_DOWNLOADED";
+
+NSString * SettingsDidChangeNotification = @"ApplicationSettingsChanged";
+NSString * CLIENT_ID = @"client.id";
+NSString * CORE_URL = @"navigator.core.url";
+NSString * CAS_SERVER_URL = @"cas.server.url";
+NSString * PGT_RECEIVE_URL = @"pgt.receive.url";
+NSString * PGT_RETRIEVE_URL = @"pgt.retrieve.url";
+NSString * PURGE_FIELDWORK_BUTTON = @"purge.fieldwork.button";
+NSString * UPCOMING_DAYS_TO_SYNC = @"upcoming.days.to.sync";
+NSString * MANUAL_MODE = @"navigator.core.manualMode";

--- a/NCSNavField.xcodeproj/project.pbxproj
+++ b/NCSNavField.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		00F940841642E08100176840 /* EventTemplateTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 00F940831642E08100176840 /* EventTemplateTest.m */; };
 		00FF37DE1417C50D0009B1D4 /* Instrument.m in Sources */ = {isa = PBXBuildFile; fileRef = 00FF37DD1417C50D0009B1D4 /* Instrument.m */; };
 		00FF37E71417D2380009B1D4 /* ContactNavigationTableTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 00FF37E41417CFA30009B1D4 /* ContactNavigationTableTest.m */; };
+		16D3DE4316FA0DE90043FC69 /* NCSFieldConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 16D3DE4216FA0DE90043FC69 /* NCSFieldConstants.m */; };
 		22226BB41666ED0F005CCE71 /* BlockActionSheet.m in Sources */ = {isa = PBXBuildFile; fileRef = 22226BAC1666ED0B005CCE71 /* BlockActionSheet.m */; };
 		22226BB51666ED0F005CCE71 /* BlockAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = 22226BAE1666ED0C005CCE71 /* BlockAlertView.m */; };
 		22226BB61666ED0F005CCE71 /* BlockBackground.m in Sources */ = {isa = PBXBuildFile; fileRef = 22226BB01666ED0D005CCE71 /* BlockBackground.m */; };
@@ -605,6 +606,8 @@
 		00FF37E31417CFA30009B1D4 /* ContactNavigationTableTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactNavigationTableTest.h; sourceTree = "<group>"; };
 		00FF37E41417CFA30009B1D4 /* ContactNavigationTableTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContactNavigationTableTest.m; sourceTree = "<group>"; };
 		162812F616B1C19200652CA2 /* 20130124192217_add_instrument_relation_to_eventTemplate.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 20130124192217_add_instrument_relation_to_eventTemplate.xcdatamodel; sourceTree = "<group>"; };
+		16D3DE4116FA0DE90043FC69 /* NCSFieldConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCSFieldConstants.h; sourceTree = "<group>"; };
+		16D3DE4216FA0DE90043FC69 /* NCSFieldConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NCSFieldConstants.m; sourceTree = "<group>"; };
 		16E839C116D8244800ED8A3C /* 20130222220953_removed_person_relation_from_contact.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 20130222220953_removed_person_relation_from_contact.xcdatamodel; sourceTree = "<group>"; };
 		16F868AE16B1E4D100F8EE32 /* 20130124215248_add_appCreated_property_to_contact.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 20130124215248_add_appCreated_property_to_contact.xcdatamodel; sourceTree = "<group>"; };
 		22226BAB1666ED0B005CCE71 /* BlockActionSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlockActionSheet.h; path = NCSNavField/BlockActionSheet.h; sourceTree = "<group>"; };
@@ -1173,6 +1176,8 @@
 		006EBEE8141673A1003D69CF /* Other */ = {
 			isa = PBXGroup;
 			children = (
+				16D3DE4116FA0DE90043FC69 /* NCSFieldConstants.h */,
+				16D3DE4216FA0DE90043FC69 /* NCSFieldConstants.m */,
 				0026E670140347E700355BCB /* NCSNavField-Info.plist */,
 				0026E671140347E700355BCB /* InfoPlist.strings */,
 			);
@@ -1654,6 +1659,7 @@
 				0029689F16BC675000524EEC /* Response.m in Sources */,
 				004E20BD16C0485B006E68DC /* JSONParserNSJSONSerialization.m in Sources */,
 				00B8756B16D56C5000CED547 /* ResponseSetMustacheContext.m in Sources */,
+				16D3DE4316FA0DE90043FC69 /* NCSFieldConstants.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NCSNavField/ApplicationSettings.h
+++ b/NCSNavField/ApplicationSettings.h
@@ -8,8 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString *const SettingsDidChangeNotification;
-
 @interface ApplicationSettings : NSObject {
     @private
     NSString* _coreURL;

--- a/NCSNavField/ApplicationSettings.m
+++ b/NCSNavField/ApplicationSettings.m
@@ -12,15 +12,6 @@
 #import "ApplicationSettings.h"
 #import "NSString+Additions.h"
 
-NSString* const SettingsDidChangeNotification = @"ApplicationSettingsChanged";
-NSString* const CLIENT_ID = @"client.id";
-NSString* const CORE_URL = @"navigator.core.url";
-NSString* const CAS_SERVER_URL = @"cas.server.url";
-NSString* const PGT_RECEIVE_URL = @"pgt.receive.url";
-NSString* const PGT_RETRIEVE_URL = @"pgt.retrieve.url";
-NSString* const PURGE_FIELDWORK_BUTTON = @"purge.fieldwork.button";
-NSString* const UPCOMING_DAYS_TO_SYNC = @"upcoming.days.to.sync";
-
 //This makes the method declaration private. This is a singleton
 //and we don't want any consumers of this class to call the init method.
 //We want them to call the instance class method. That enforces its

--- a/NCSNavField/NCSNavField-Prefix.pch
+++ b/NCSNavField/NCSNavField-Prefix.pch
@@ -19,6 +19,7 @@
 #endif
 
 #import "NCSNavFieldAppDelegate.h"
+#import "NCSFieldConstants.h"
 #define UIAppDelegate ((NCSNavFieldAppDelegate *)[UIApplication sharedApplication].delegate)
 
 //#if __cplusplus


### PR DESCRIPTION
Due to the way the data was stored on the Root View Controller's table, when a new participant was deleted, the wrong object may have been deleted. Also, some constants have been moved into their own file.
