### PR TITLE
Add additional details to provider list. Feature #3641

### DIFF
--- a/NCSNavField.xcodeproj/project.pbxproj
+++ b/NCSNavField.xcodeproj/project.pbxproj
@@ -605,6 +605,7 @@
 		00FF37E31417CFA30009B1D4 /* ContactNavigationTableTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactNavigationTableTest.h; sourceTree = "<group>"; };
 		00FF37E41417CFA30009B1D4 /* ContactNavigationTableTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContactNavigationTableTest.m; sourceTree = "<group>"; };
 		162812F616B1C19200652CA2 /* 20130124192217_add_instrument_relation_to_eventTemplate.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 20130124192217_add_instrument_relation_to_eventTemplate.xcdatamodel; sourceTree = "<group>"; };
+		16821E80170393AF003613A1 /* 20130327205234_added_address_unit_to_practice.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = file; path = 20130327205234_added_address_unit_to_practice.xcdatamodel; sourceTree = "<group>"; };
 		16E839C116D8244800ED8A3C /* 20130222220953_removed_person_relation_from_contact.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 20130222220953_removed_person_relation_from_contact.xcdatamodel; sourceTree = "<group>"; };
 		16F868AE16B1E4D100F8EE32 /* 20130124215248_add_appCreated_property_to_contact.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 20130124215248_add_appCreated_property_to_contact.xcdatamodel; sourceTree = "<group>"; };
 		22226BAB1666ED0B005CCE71 /* BlockActionSheet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlockActionSheet.h; path = NCSNavField/BlockActionSheet.h; sourceTree = "<group>"; };
@@ -1961,6 +1962,7 @@
 				0097198016CA8E0A001925A8 /* 20130212144148_add_instrument_context_to_response_set.xcdatamodel */,
 				00B8756416D5640D00CED547 /* 20130220200434_remove_instrument_context_from_response_set.xcdatamodel */,
 				16E839C116D8244800ED8A3C /* 20130222220953_removed_person_relation_from_contact.xcdatamodel */,
+				16821E80170393AF003613A1 /* 20130327205234_added_address_unit_to_practice.xcdatamodel */,
 				00140E2816C0267E0074AB6B /* 20130204172431_remove_instrument_plan_relationship_from_instrument.xcdatamodel */,
 				002968A316BC7D3E00524EEC /* 20130201224552_change_response_entity_name.xcdatamodel */,
 				00BB5C4A167EC70D00EAE043 /* 20121217031937_move_response_templates_relationship_to_event_templates.xcdatamodel */,
@@ -1998,7 +2000,7 @@
 				0037D8C015F6881C00C6B7EB /* 20120904190344_change_response_set_entity.xcdatamodel */,
 				00C9C6E4146CE66300F6D339 /* main.xcdatamodel */,
 			);
-			currentVersion = 16E839C116D8244800ED8A3C /* 20130222220953_removed_person_relation_from_contact.xcdatamodel */;
+			currentVersion = 16821E80170393AF003613A1 /* 20130327205234_added_address_unit_to_practice.xcdatamodel */;
 			name = main.xcdatamodeld;
 			path = NCSNavField/main.xcdatamodeld;
 			sourceTree = "<group>";

--- a/NCSNavField/Provider.h
+++ b/NCSNavField/Provider.h
@@ -13,6 +13,8 @@
 @property (nonatomic, retain) NSString * location;
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) NSNumber * practiceNum;
+@property (nonatomic, strong) NSString * addressOne;
+@property (nonatomic, strong) NSString * unit;
 @property (nonatomic, retain) NSNumber * recruited;
 
 @end

--- a/NCSNavField/Provider.m
+++ b/NCSNavField/Provider.m
@@ -14,6 +14,8 @@
 @dynamic location;
 @dynamic name;
 @dynamic practiceNum;
+@dynamic addressOne;
+@dynamic unit;
 @dynamic recruited;
 
 @end

--- a/NCSNavField/ProviderListViewController.m
+++ b/NCSNavField/ProviderListViewController.m
@@ -50,11 +50,20 @@ NSString* const PROVIDER_SELECTED_NOTIFICATION_KEY = @"ProviderSelected";
     
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil) {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:CellIdentifier];
     }
     
     Provider* provider = [self.providers objectAtIndex:indexPath.row];
     cell.textLabel.text = provider.name;
+    if (provider.addressOne && provider.unit) {
+        cell.detailTextLabel.text = [NSString stringWithFormat:@"%@ (%@)", provider.addressOne, provider.unit];
+    }
+    else if (provider.addressOne) {
+        cell.detailTextLabel.text = provider.addressOne;
+    }
+    else {
+        cell.detailTextLabel.text = @"No address provided.";
+    }
     
     return cell;
 }

--- a/NCSNavField/RestKitSettings.m
+++ b/NCSNavField/RestKitSettings.m
@@ -292,6 +292,8 @@ static RestKitSettings* instance;
      @"name", @"name",
      @"location", @"location",
      @"practice_num", @"practiceNum",
+     @"address_one", @"addressOne",
+     @"unit", @"unit",
      @"recruited", @"recruited", nil];
     [objectManager.mappingProvider setMapping:provider forKeyPath:@"providers"];
 }

--- a/NCSNavField/SurveyContextGenerator.m
+++ b/NCSNavField/SurveyContextGenerator.m
@@ -35,6 +35,16 @@
                     forKey:@"practice_num"];
         }
         
+        if (self.provider.addressOne) {
+            [ctx setObject:self.provider.addressOne
+                    forKey:@"address_one"];
+        }
+        
+        if (self.provider.unit) {
+            [ctx setObject:self.provider.unit
+                    forKey:@"unit"];
+        }
+        
         if (self.provider.name) {
             [ctx setObject:self.provider.name
                     forKey:@"name_practice"];

--- a/NCSNavField/main.xcdatamodeld/.xccurrentversion
+++ b/NCSNavField/main.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>20130222220953_removed_person_relation_from_contact.xcdatamodel</string>
+	<string>20130327205234_added_address_unit_to_practice.xcdatamodel</string>
 </dict>
 </plist>

--- a/NCSNavField/main.xcdatamodeld/20130327205234_added_address_unit_to_practice.xcdatamodel/contents
+++ b/NCSNavField/main.xcdatamodeld/20130327205234_added_address_unit_to_practice.xcdatamodel/contents
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model name="" userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="2061" systemVersion="12D78" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="Contact" representedClassName="Contact" syncable="YES">
+        <attribute name="appCreated" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="comments" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="contactId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="date" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="dispositionCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="distanceTraveled" optional="YES" attributeType="Decimal" syncable="YES"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="initiated" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="interpreterId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="interpreterOther" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="languageId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="languageOther" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="locationId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="locationOther" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="personId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="privateDetail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="privateId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="typeId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="whoContactedId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="whoContactedOther" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="events" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Event" inverseName="contact" inverseEntity="Event" syncable="YES"/>
+        <relationship name="fieldWork" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Fieldwork" inverseName="contacts" inverseEntity="Fieldwork" syncable="YES"/>
+    </entity>
+    <entity name="DispositionCode" representedClassName="DispositionCode" syncable="YES">
+        <attribute name="categoryCode" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="disposition" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="finalCategory" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="finalCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="interimCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subCategory" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Event" representedClassName="Event" syncable="YES">
+        <attribute name="breakOffId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="comments" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dispositionCategoryId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="dispositionCode" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="eventId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="eventRepeatKey" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="eventTypeCode" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="eventTypeOther" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="incentiveCash" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="incentiveNonCash" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="incentiveTypeId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="contact" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Contact" inverseName="events" inverseEntity="Contact" syncable="YES"/>
+        <relationship name="instruments" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Instrument" inverseName="event" inverseEntity="Instrument" syncable="YES"/>
+    </entity>
+    <entity name="EventTemplate" representedClassName="EventTemplate" syncable="YES">
+        <attribute name="eventRepeatKey" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="eventTypeCode" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <relationship name="instruments" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="Instrument" inverseName="eventTemplate" inverseEntity="Instrument" syncable="YES"/>
+        <relationship name="responseTemplates" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ResponseTemplate" syncable="YES"/>
+    </entity>
+    <entity name="Fieldwork" representedClassName="Fieldwork" syncable="YES">
+        <attribute name="retrievedDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="uri" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="contacts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Contact" inverseName="fieldWork" inverseEntity="Contact" syncable="YES"/>
+        <relationship name="instrumentTemplates" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="InstrumentTemplate" inverseName="fieldWork" inverseEntity="InstrumentTemplate" syncable="YES"/>
+        <relationship name="participants" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Participant" inverseName="fieldWork" inverseEntity="Participant" syncable="YES"/>
+    </entity>
+    <entity name="Instrument" representedClassName="Instrument" syncable="YES">
+        <attribute name="breakOffId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="comment" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dataProblemId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="instrumentId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="instrumentMethodId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="instrumentModeId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="instrumentModeOther" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="instrumentPlanId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="instrumentTypeId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="instrumentTypeOther" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="instrumentVersion" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="repeatKey" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="statusId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <attribute name="supervisorReviewId" optional="YES" attributeType="Integer 16" syncable="YES"/>
+        <relationship name="event" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Event" inverseName="instruments" inverseEntity="Event" syncable="YES"/>
+        <relationship name="eventTemplate" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="EventTemplate" inverseName="instruments" inverseEntity="EventTemplate" syncable="YES"/>
+        <relationship name="responseSets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ResponseSet" inverseName="instrument" inverseEntity="ResponseSet" syncable="YES"/>
+    </entity>
+    <entity name="InstrumentPlan" representedClassName="InstrumentPlan" syncable="YES">
+        <attribute name="instrumentPlanId" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="instrumentTemplates" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="InstrumentTemplate" inverseName="instrumentPlan" inverseEntity="InstrumentTemplate" syncable="YES"/>
+    </entity>
+    <entity name="InstrumentTemplate" representedClassName="InstrumentTemplate" syncable="YES">
+        <attribute name="instrumentTemplateId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="participantType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="representation" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="fieldWork" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Fieldwork" inverseName="instrumentTemplates" inverseEntity="Fieldwork" syncable="YES"/>
+        <relationship name="instrumentPlan" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="InstrumentPlan" inverseName="instrumentTemplates" inverseEntity="InstrumentPlan" syncable="YES"/>
+        <relationship name="questions" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="NUQuestion" inverseName="instrumentTemplate" inverseEntity="NUQuestion" syncable="YES"/>
+    </entity>
+    <entity name="MdesCode" syncable="YES">
+        <attribute name="displayText" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="listName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="localCode" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+    </entity>
+    <entity name="MergeStatus" representedClassName="MergeStatus" syncable="YES">
+        <attribute name="createdAt" attributeType="Date" syncable="YES"/>
+        <attribute name="mergeStatusId" attributeType="String" syncable="YES"/>
+        <attribute name="status" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="NUAnswer" representedClassName="NUAnswer" syncable="YES">
+        <attribute name="referenceIdentifier" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <relationship name="question" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="NUQuestion" inverseName="answers" inverseEntity="NUQuestion" syncable="YES"/>
+    </entity>
+    <entity name="NUQuestion" representedClassName="NUQuestion" syncable="YES">
+        <attribute name="referenceIdentifier" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <relationship name="answers" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="NUAnswer" inverseName="question" inverseEntity="NUAnswer" syncable="YES"/>
+        <relationship name="instrumentTemplate" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="InstrumentTemplate" inverseName="questions" inverseEntity="InstrumentTemplate" syncable="YES"/>
+    </entity>
+    <entity name="Participant" representedClassName="Participant" syncable="YES">
+        <attribute name="pId" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="fieldWork" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Fieldwork" inverseName="participants" inverseEntity="Fieldwork" syncable="YES"/>
+        <relationship name="persons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Person" inverseName="participant" inverseEntity="Person" syncable="YES"/>
+    </entity>
+    <entity name="Person" representedClassName="Person" syncable="YES">
+        <attribute name="cellPhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="city" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="homePhone" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="middleName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="personId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="prefixCode" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="relationshipCode" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="state" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="street" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="suffixCode" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="zipCode" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="participant" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Participant" inverseName="persons" inverseEntity="Participant" syncable="YES"/>
+    </entity>
+    <entity name="Provider" representedClassName="Provider" syncable="YES">
+        <attribute name="addressOne" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="location" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="practiceNum" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="recruited" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="unit" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Response" representedClassName="Response" syncable="YES">
+        <attribute name="answer" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="modifiedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="question" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="responseGroup" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="responseSet" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="ResponseSet" inverseName="responses" inverseEntity="ResponseSet" syncable="YES"/>
+    </entity>
+    <entity name="ResponseSet" representedClassName="ResponseSet" syncable="YES">
+        <attribute name="completedAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="personId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="survey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="instrument" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Instrument" inverseName="responseSets" inverseEntity="Instrument" syncable="YES"/>
+        <relationship name="responses" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Response" inverseName="responseSet" inverseEntity="Response" syncable="YES"/>
+    </entity>
+    <entity name="ResponseTemplate" representedClassName="ResponseTemplate" syncable="YES">
+        <attribute name="aref" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="qref" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="surveyId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Contact" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="DispositionCode" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Event" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="EventTemplate" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Fieldwork" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Instrument" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="InstrumentPlan" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="InstrumentTemplate" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="MdesCode" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="MergeStatus" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="NUAnswer" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="NUQuestion" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Participant" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Person" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Provider" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="Response" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="ResponseSet" positionX="0" positionY="0" width="0" height="0"/>
+        <element name="ResponseTemplate" positionX="0" positionY="0" width="0" height="0"/>
+    </elements>
+</model>

--- a/NCSNavFieldTests/SurveyContextGeneratorTest.m
+++ b/NCSNavFieldTests/SurveyContextGeneratorTest.m
@@ -20,6 +20,8 @@ static Provider* provider;
     provider = [Provider object];
     provider.name = @"Northwestern";
     provider.location = @"XYZ123";
+    provider.addressOne = @"123 Anystreet";
+    provider.unit = @"A";
     provider.practiceNum = [NSNumber numberWithInt:4];
 }
 

--- a/ncs-core-stub/providers.json
+++ b/ncs-core-stub/providers.json
@@ -1,15 +1,24 @@
 {
     "providers": [
         {
+            "address_one": "21 Jump St",
             "location": "1",
             "name": "Northwestern Memorial Hospital", 
             "practice_num": 1, 
-            "recruited": true
+            "recruited": true,
+            "unit": "Suite 3456"
         },
         {
+            "address_one": "123 Sesame St",
             "location": "2",
             "name": "Baylor Health Care System", 
             "practice_num": null, 
+            "recruited": true
+        },
+        {
+            "location": "3",
+            "name": "Lady M", 
+            "practice_num": 2, 
             "recruited": true
         },
         {


### PR DESCRIPTION
Added the ability for the provider model object to have "addressOne" and "unit" properties. I also altered the display of the providers during screening to reflect these changes. (see attached)

![Screen Shot 2013-03-28 at 10 30 41 AM](https://f.cloud.github.com/assets/109652/313998/e1e22d56-97be-11e2-8a1e-08747214a9fa.png)
